### PR TITLE
Update HistoryNode to correctly describe changes to levels of evidence

### DIFF
--- a/app/domain/history_node.rb
+++ b/app/domain/history_node.rb
@@ -15,6 +15,22 @@ class HistoryNode
 
   # add 'parent'?/ 'on'?
 
+  # # # NAMED_FOREIGN_KEYS
+  # # Shows changesets of foreign key columns using their human names.  So ScItem evidence_id would show: "x changed from 'B' to 'C'" rather than "x changed from '2' to '3'"
+  # # To use, add the instance method `foreign_key_name` to the foreign_key attribute's model to specify what foreign key value to show (a), then reference add the attribute's foreign key / Model hash below (b):
+  # # a) Evidence#foreign_key_name
+  # # b) "evidence_id" => Evidence
+
+  NAMED_FOREIGN_KEYS = {"evidence_id" => Evidence}
+
+  def self.show_attribute(attribute, changeset_value)
+    if NAMED_FOREIGN_KEYS.include?(attribute) && NAMED_FOREIGN_KEYS[attribute].safe_find(changeset_value).present?
+      NAMED_FOREIGN_KEYS[attribute].safe_find(changeset_value).try(:foreign_key_name) # E.g. Evidence.find(2).foreign_key_name => "B"
+    else
+      changeset_value
+    end
+  end
+
   attr_reader :raw
   delegate :datetime, :changeset, :secret_editor, to: :raw
 

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -16,4 +16,8 @@ class Evidence < ActiveRecord::Base
   def definition_as_html
     BlueCloth.new(definition).to_html.html_safe
   end
+
+  def foreign_key_name # for HistoryNode
+    level
+  end
 end

--- a/app/views/history/_changeset.html.haml
+++ b/app/views/history/_changeset.html.haml
@@ -5,16 +5,17 @@
       %li
         = node.target_klass.human_attribute_name(attribute)
         = "changed from"
-        %em= human_attribute_value(node.target_klass, attribute, changeset[0])
+        %em= human_attribute_value(node.target_klass, attribute, HistoryNode.show_attribute(attribute, changeset[0]))
         = "to"
-        %em= human_attribute_value(node.target_klass, attribute, changeset[1])
+        %em= human_attribute_value(node.target_klass, attribute, HistoryNode.show_attribute(attribute, changeset[1]))
+
     - elsif changeset[0].present?
       %li
         = node.target_klass.human_attribute_name(attribute)
         = "is no longer"
-        %em= human_attribute_value(node.target_klass, attribute, changeset[0])
+        %em= human_attribute_value(node.target_klass, attribute, HistoryNode.show_attribute(attribute, changeset[0]))
     - elsif changeset[1].present?
       %li
         = node.target_klass.human_attribute_name(attribute)
         = "became"
-        %em= human_attribute_value(node.target_klass, attribute, changeset[1])
+        %em= human_attribute_value(node.target_klass, attribute, HistoryNode.show_attribute(attribute, changeset[1]))


### PR DESCRIPTION
I had these changes finished on my computer uncommitted from the Levels of Evidence feature build so here's a PR to add them.  It changes `HistoryNode` to make foreign keys more readable.

- In history, foreign_key columns currently show `id` integer values rather than
  human readable values if the column is a foreign key.
- With this commit, an `ScItem` given an `evidence_id` of `1` would now show up as `A` rather than `1` in the history summary.  E.g. `"Level of Evidence changed from 2 to 1"` would now show as `"Level of Evidence changed from B to C"`
- Finally I added `NAMED_FOREIGN_KEYS` as a way to deal with other foreign keys that
  may also have this problem.  Foreign key exceptions need to be explicitly added by adding a `foreign_key_name` method to that Model.

I'm nearly certain this change will still work with the current project, though feel free to give them a test.  I wouldn't be surprised if other foreign key values are doing this as well in history so it may be worth keeping an out for them.